### PR TITLE
Fix Install-DscExe

### DIFF
--- a/.build/tasks/PSDSC.Install.ps1
+++ b/.build/tasks/PSDSC.Install.ps1
@@ -64,7 +64,7 @@ task PSDSC.Windows.Install {
 
     $releases = Invoke-RestMethod -Uri $base
 
-    $fileName = 'DSC-3.0.0-x86_64-pc-windows-msvc.zip'
+    $fileName = 'DSC-*-x86_64-pc-windows-msvc.zip'
     # get latest asset to be downloaded
     $asset = $releases.assets | Where-Object -Property Name -Like $fileName
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2025-04-11
+
+### Fixed
+
+- Wildcard when installing `dsc.exe`
+
 ## [1.2.0] - 2025-03-14
 
 ### Fixed

--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -28,6 +28,7 @@ function Install-DscExe
     #>
     [CmdletBinding()]
     [OutputType([System.Boolean])]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", "PowerShell 7")]
     param (
         [Parameter()]
         [ArgumentCompleter([VersionCompleter])]

--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -28,7 +28,7 @@ function Install-DscExe
     #>
     [CmdletBinding()]
     [OutputType([System.Boolean])]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", "PowerShell 7")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", "")]
     param (
         [Parameter()]
         [ArgumentCompleter([VersionCompleter])]

--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -61,7 +61,7 @@ function Install-DscExe
     {
         if ($Force.IsPresent -or -not $dscInstalled)
         {
-            $fileName = 'DSC-3.0.0-x86_64-pc-windows-msvc.zip'
+            $fileName = 'DSC-*-x86_64-pc-windows-msvc.zip'
             # get latest asset to be downloaded
             $asset = $releases.assets | Where-Object -Property Name -Like $fileName
 
@@ -116,7 +116,6 @@ function Install-DscExe
         }
         else
         {
-            # TODO: When DSC is fully available in GitHub, compare versions and install if newer
             Write-Warning -Message "DSC is already installed. Use -Force to reinstall."
             return $true
         }
@@ -125,14 +124,15 @@ function Install-DscExe
     {
         if ($UseVersion)
         {
-            $filePath = '/tmp/DSC-' + $Version + '-x86_64-unknown-linux-gnu.tar.gz'
-            $uri = "https://github.com/PowerShell/DSC/releases/download/v$Version/DSC-$Version-x86_64-unknown-linux-gnu.tar.gz"
+            $filePath = [System.IO.Path]::Combine($env:TEMP, "DSC-$Version-x86_64-linux.tar.gz")
+            $uri = "https://github.com/PowerShell/DSC/releases/download/v$Version/DSC-$Version-x86_64-linux.tar.gz"
         }
         else
         {
-            $filePath = '/tmp/DSC-3.0.0-x86_64-unknown-linux-gnu.tar.gz'
-            $fileName = 'DSC-3.0.0-*-x86_64-unknown-linux-gnu.tar.gz'
-            $uri = ($releases.assets | Where-Object -Property Name -Like $fileName).browser_download_url
+            $fileName = 'DSC-*-x86_64-linux.tar.gz'
+            $asset = $releases.assets | Where-Object -Property Name -Like $fileName
+            $filePath = [System.IO.Path]::Combine($env:TEMP, $asset.name)
+            $uri = $asset.browser_download_url
         }
 
         Write-Verbose -Message "Using URI: $uri on path: $filePath"
@@ -150,7 +150,7 @@ function Install-DscExe
         sudo ln -s /opt/microsoft/dsc /usr/bin/dsc
 
         # Add to path
-        $env:PATH += [System.IO.Path]::PathSeparator + "/usr/bin/dsc"
+        $env:PATH += [System.IO.Path]::PathSeparator + (Join-Path 'usr' 'bin' 'dsc')
 
         return $true
     }
@@ -158,14 +158,15 @@ function Install-DscExe
     {
         if ($UseVersion)
         {
-            $filePath = '/tmp/DSC-' + $Version + '-x86_64-apple-darwin.tar.gz'
+            $filePath = [System.IO.Path]::Combine($env:TEMP, "DSC-$Version-x86_64-apple-darwin.tar.gz")
             $uri = "https://github.com/PowerShell/DSC/releases/download/v$Version/DSC-$Version-x86_64-apple-darwin.tar.gz"
         }
         else
         {
-            $filePath = '/tmp/DSC-3.0.0-x86_64-apple-darwin.tar.gz'
-            $fileName = 'DSC-3.0.0-*-x86_64-apple-darwin.tar.gz'
-            $uri = ($releases.assets | Where-Object -Property Name -Like $fileName).browser_download_url
+            $fileName = 'DSC-*-x86_64-apple-darwin.tar.gz'
+            $asset = $releases.assets | Where-Object -Property Name -Like $fileName
+            $filePath = [System.IO.Path]::Combine($env:TEMP, $asset.name)
+            $uri = $asset.browser_download_url
         }
 
         curl -L -o $filePath $uri
@@ -183,6 +184,8 @@ function Install-DscExe
 
         Get-ChildItem -Path /usr/local/microsoft/dsc -Recurse
         # Add to path
-        $env:PATH += [System.IO.Path]::PathSeparator + "/usr/local/microsoft/dsc"
+        $env:PATH += [System.IO.Path]::PathSeparator + (Join-Path 'usr' 'local' 'microsoft' 'dsc')
+
+        return $true
     }
 }

--- a/tests/Integration/Private/DSC/Get-CurrentDscExeVersion.tests.ps1
+++ b/tests/Integration/Private/DSC/Get-CurrentDscExeVersion.tests.ps1
@@ -46,7 +46,7 @@ Describe 'Get-CurrentDscExeVersion' -Tag Private, Integration {
         It 'Should return a valid version string' {
             InModuleScope -ScriptBlock {
                 $result = Get-CurrentDscExeVersion
-                $result | Should -Match '3.0.0-*'
+                $result | Should -Match '3.0.*'
             }
         }
     }

--- a/tests/Unit/Private/DSC/Get-CurrentDscExeVersion.tests.ps1
+++ b/tests/Unit/Private/DSC/Get-CurrentDscExeVersion.tests.ps1
@@ -23,11 +23,11 @@ AfterAll {
 
 Describe 'Get-CurrentDscExeVersion' -Tag Private, Unit {
     Context 'Check if DSC version is retrieved' {
-        Mock -CommandName 'Get-CurrentDscExeVersion' -MockWith { return '3.0.0-1234' }
+        Mock -CommandName 'Get-CurrentDscExeVersion' -MockWith { return '3.0.2' }
         It 'Should return a valid version string' {
             InModuleScope -ScriptBlock {
                 $result = Get-CurrentDscExeVersion
-                $result | Should -Match '3.0.0-*'
+                $result | Should -Match '3.0.*'
             }
         }
     }


### PR DESCRIPTION
In this pull request, small adjustments are made to align with the new assets name in the DSC repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new version entry `[1.2.1] - 2025-04-11` to the changelog, detailing the fix for wildcard functionality in the installation process.

- **Bug Fixes**
  - Resolved an issue with wildcard functionality when installing `dsc.exe`, ensuring correct asset selection across different operating systems.
  
- **Tests**
  - Updated test cases to accommodate broader version format matching for `Get-CurrentDscExeVersion`, improving validation accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->