### PR TITLE
Rewrite logic ConvertTo-PsDsc* commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2025-04-24
+
+### Changed
+
+- Changed the way how `ConvertTo-PsDsc*` commands work with adapters
+
 ## [1.2.1] - 2025-04-11
 
 ### Fixed

--- a/source/Private/DSC/Build-DscConfigDocument.ps1
+++ b/source/Private/DSC/Build-DscConfigDocument.ps1
@@ -49,11 +49,16 @@ function Build-DscConfigDocument
     # start by declaring the configuration document
     $configurationDocument = [ordered]@{
         "`$schema" = "https://aka.ms/dsc/schemas/v3/bundled/config/document.json"
-        resources  = $null
+        resources  = @()
     }
 
     # convert all objects to hashtables
     $dscObjects = ConvertTo-DscObject @PSBoundParameters -ErrorAction SilentlyContinue
+
+    if (-not $dscObjects -or $dscObjects.Count -eq 0)
+    {
+        Write-Warning "ConvertTo-DscObject returned no objects. Conversion may have failed."
+    }
 
     # store all resources in variables
     $resources = [System.Collections.Generic.List[object]]::new()
@@ -63,7 +68,7 @@ function Build-DscConfigDocument
         $resource = [PSCustomObject]@{
             name       = $dscObject.ResourceInstanceName
             type       = ("{0}/{1}" -f $dscObject.ModuleName, $dscObject.ResourceName)
-            properties = $null
+            properties = @()
         }
 
         $properties = [ordered]@{}
@@ -79,7 +84,7 @@ function Build-DscConfigDocument
         # add properties
         $resource.properties = $properties
 
-        if ($dscObject.ContainsKey('DependsOn'))
+        if ($dscObject.ContainsKey('DependsOn') -and $dscObject.DependsOn)
         {
             $dependsOnKeys = $dscObject.DependsOn.Split("]").Replace("[", "")
 

--- a/source/Private/DSC/ConvertTo-DscObject.ps1
+++ b/source/Private/DSC/ConvertTo-DscObject.ps1
@@ -198,12 +198,6 @@ function ConvertTo-DscObject
         $currentResourceInfo.Add("ResourceInstanceName", $resourceInstanceName)
         $currentResourceInfo.Add("ModuleName", $ModulesToLoad.ModuleName)
         $currentResourceInfo.Add("ConfigurationName", $configurationName)
-        $adapter = 'Microsoft.DSC/PowerShell'
-        if ($PSVersionTable.PSEdition -ne 'Core')
-        {
-            $adapter = 'Microsoft.Windows/WindowsPowerShell'
-        }
-        $currentResourceInfo.Add("Type", $adapter)
 
         # Get a reference to the current resource.
         $currentResource = $DSCResources | Where-Object -FilterScript { $_.Name -eq $resourceType }

--- a/source/Public/ConvertTo-PsDscYaml.ps1
+++ b/source/Public/ConvertTo-PsDscYaml.ps1
@@ -92,10 +92,20 @@ function ConvertTo-PsDscYaml
     end
     {
         Write-Verbose ("Ended: {0}" -f $MyInvocation.MyCommand.Name)
-        if (-not (Get-Module -ListAvailable yayaml -ErrorAction SilentlyContinue) -or (Get-Module -ListAvailable powershell-yaml))
+        $yamlCommand = Get-Command -Name ConvertTo-Yaml -ErrorAction SilentlyContinue
+        if ($yamlCommand)
         {
-            $inputObject = ConvertTo-Yaml -InputObject $configurationDocument -Depth 10
+            $yamlParams = @{}
+            if ($yamlCommand.Parameters.ContainsKey('Depth'))
+            {
+                $yamlParams = @{
+                    Depth = 10
+                }
+            }
+
+            return ($configurationDocument | ConvertTo-Yaml @yamlParams)
         }
-        return $inputObject
+
+        return $configurationDocument
     }
 }

--- a/tests/Unit/Public/ConvertTo-PsDscJson.tests.ps1
+++ b/tests/Unit/Public/ConvertTo-PsDscJson.tests.ps1
@@ -30,22 +30,23 @@ configuration MyConfiguration {
         It 'Should return valid JSON using file path' -Skip:(!$IsWindows) {
             $json = ConvertTo-PsDscJson -Path $filePath
             $out = $json | ConvertFrom-Json -Depth 10
-            $out.resources.name | Should -Be 'MyConfiguration'
-            $out.resources.type | Should -BeLike '*PowerShell*'
-            $out.resources.properties.resources.properties.Name | Should -Not -BeNullOrEmpty
-            $out.resources.properties.resources.properties.Value | Should -Not -BeNullOrEmpty
-            $out.resources.properties.resources.properties.Ensure | Should -Not -BeNullOrEmpty
-            $out.resources.properties.resources.properties.Path | Should -Not -BeNullOrEmpty
+            $out.resources.name | Should -Be 'CreatePathEnvironmentVariable'
+            $out.resources.type | Should -Be 'PSDesiredStateConfiguration/Environment'
+            $out.resources.properties.Value | Should -Be 'TestValue'
+            $out.resources.properties.Name | Should -Be 'TestPathEnvironmentVariable'
+            $out.resources.properties.Ensure | Should -Be 'Present'
+            $out.resources.properties.Path | Should -BeTrue
         }
+
         It 'Should return valid JSON using content' -Skip:(!$IsWindows) {
             $json = ConvertTo-PsDscJson -Content $content
             $out = $json | ConvertFrom-Json -Depth 10
-            $out.resources.name | Should -Be 'MyConfiguration'
-            $out.resources.type | Should -BeLike '*PowerShell*'
-            $out.resources.properties.resources.properties.Name | Should -Not -BeNullOrEmpty
-            $out.resources.properties.resources.properties.Value | Should -Not -BeNullOrEmpty
-            $out.resources.properties.resources.properties.Ensure | Should -Not -BeNullOrEmpty
-            $out.resources.properties.resources.properties.Path | Should -Not -BeNullOrEmpty
+            $out.resources.name | Should -Be 'CreatePathEnvironmentVariable'
+            $out.resources.type | Should -Be 'PSDesiredStateConfiguration/Environment'
+            $out.resources.properties.Value | Should -Be 'TestValue'
+            $out.resources.properties.Name | Should -Be 'TestPathEnvironmentVariable'
+            $out.resources.properties.Ensure | Should -Be 'Present'
+            $out.resources.properties.Path | Should -BeTrue
         }
     }
 }

--- a/tests/Unit/Public/ConvertTo-PsDscYaml.tests.ps1
+++ b/tests/Unit/Public/ConvertTo-PsDscYaml.tests.ps1
@@ -1,4 +1,4 @@
-Describe 'ConvertTo-DscYaml' {
+Describe 'ConvertTo-PsDscYaml' {
     Context 'Converts PowerShell script to DSC v3 YAML' {
         BeforeAll {
             $script:filePath = (Join-Path -Path $TestDrive -ChildPath 'test.ps1')
@@ -14,24 +14,22 @@ configuration MyConfiguration {
             Value = 'TestValue'
             Ensure = 'Present'
             Path = $true
-            Target = @('Process')
         }
     }
 }
 '@
             Set-Content -Path $filePath -Value $content
-
-            $script:skip = (Get-Command ConvertFrom-Yaml).Parameters.Keys -contains 'InputObject'
         }
 
         AfterAll {
             Remove-Item -Path $filePath -Recurse -Force
         }
 
-        It 'Should return valid YAML' -Skip:(!$skip) {
+        It 'Should return valid YAML' {
             $yaml = ConvertTo-PsDscYaml -Path $filePath
             $out = $yaml | ConvertFrom-Yaml
-            $out.resources.name | Should -Be 'MyConfiguration'
+            $out.resources.name | Should -Be 'CreatePathEnvironmentVariable'
+            $out.resources.type | Should -Be 'PSDesiredStateConfiguration/Environment'
         }
     }
 }


### PR DESCRIPTION
This PR addresses issue #15. It removed the whole adapter as from v3.1.0-preview.2 onwards, it isn't required anymore. Also slightly adjusted the way how `ConvertTo-Yaml` is being called to be more consistent. Added dependsOn to convertion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new changelog entry for version 1.2.2, documenting changes to command behavior.
- **Refactor**
  - Improved internal structure and dependency handling for generated configuration documents.
  - Enhanced YAML conversion logic for broader compatibility.
- **Tests**
  - Updated unit tests to reflect new output structure and expected values.
  - Adjusted test suite names and assertions for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->