### PR TITLE
Add `IncludePrerelease` parameter in `Install-DscExe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Install-DscExe` can now install latest prerelease when using parameter
+  `IncludePrerelease`.
+
 ## [1.2.3] - 2025-04-25
 
 ### Fixed

--- a/tests/Integration/Public/Install-DscExe.tests.ps1
+++ b/tests/Integration/Public/Install-DscExe.tests.ps1
@@ -25,5 +25,9 @@ Describe 'Install-DscExe' -Tag Public, Integration {
         It 'Should install the executable with -Force on Windows' -Skip:(!$IsWindows) {
             Install-DscExe -Force | Should -Be $true
         }
+
+        It 'Should install the executable with -IncludePrerelease on Windows' -Skip:(!$IsWindows) {
+            Install-DscExe -IncludePrerelease | Should -Be $true
+        }
     }
 }


### PR DESCRIPTION
### Added

- `Install-DscExe` can now install latest prerelease when using parameter
  `IncludePrerelease`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for installing the latest prerelease version using the `IncludePrerelease` option with the installation command.
- **Documentation**
  - Updated the changelog to reflect the new prerelease installation capability.
- **Tests**
  - Added an integration test to verify prerelease installation functionality on Windows systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->