### PR TITLE
Update symbolic link creation for DSC executable to use /usr/local/bin

### DIFF
--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -170,7 +170,8 @@ function Install-DscExe
         sudo chmod +x /opt/microsoft/dsc/dsc
 
         # Create the symbolic link that points to dsc executable
-        sudo ln -fs /opt/microsoft/dsc/dsc /usr/bin/dsc
+        sudo mkdir -p /usr/local/bin
+        sudo ln -fs /opt/microsoft/dsc/dsc /usr/local/bin/dsc
 
         return $true
     }
@@ -201,8 +202,9 @@ function Install-DscExe
         # Set execute permissions on the dsc executable
         sudo chmod +x /usr/local/microsoft/dsc/dsc
 
-        # Create the symbolic link that points to dsc executable
-        sudo ln -fs /usr/local/microsoft/dsc/dsc /usr/bin/dsc
+        # Create the symbolic link that points to dsc executables
+        sudo mkdir -p /usr/local/bin
+        sudo ln -fs /usr/local/microsoft/dsc/dsc /usr/local/bin/dsc
 
         return $true
     }


### PR DESCRIPTION
On Linux /usr/bin isn't locked down, but it's intended for distribution-managed packages so we should not put links
there for manually installed tools. On macOS, /usr/bin is protected by SIP so we can't create links there at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the installation script to place the DSC executable's symbolic link in `/usr/local/bin` instead of `/usr/bin` on Linux and macOS systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->