### PR TITLE
Fix PreRelease and version assert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Assert if DSC versions are available from GitHub
+- Validate if `IncludePreRelease` is provided if it is an actual PreRelease version
+
+## [1.3.0] - 2025-07-18
+
 - `Install-DscExe`
   - Support authenticating against GitHub using a token when accessing
     current release information.

--- a/Resolve-Dependency.psd1
+++ b/Resolve-Dependency.psd1
@@ -8,7 +8,7 @@
     #Proxy = ''
     #ProxyCredential = '$MyCredentialVariable' #TODO: find a way to support credentials in build (resolve variable)
 
-    Gallery         = 'PSGallery'
+    Gallery              = 'PSGallery'
 
     # To use a private nuget repository change the following to your own feed. The locations must be a Nuget v2 feed due
     # to limitation in PowerShellGet v2.x. Example below is for a Azure DevOps Server project-scoped feed. While resolving
@@ -30,8 +30,8 @@
 
     #AllowOldPowerShellGetModule = $true
     #MinimumPSDependVersion = '0.3.0'
-    AllowPrerelease = $false
-    WithYAML        = $true # Will also bootstrap PowerShell-Yaml to read other config files
+    AllowPrerelease      = $false
+    WithYAML             = $true # Will also bootstrap PowerShell-Yaml to read other config files
 
     # Enable ModuleFast to resolve dependencies. Requires PowerShell 7.2 or higher.
     # If this is not configured or set to $false then PowerShellGet and PackageManagement
@@ -41,9 +41,8 @@
     # Enable PSResourceGet to resolve dependencies. Requires PowerShell 7.2 or higher.
     # If this is not configured or set to $false then PowerShellGet and PackageManagement
     # will be used to resolve dependencies.
-    #UsePSResourceGet = $true
-    #PSResourceGetVersion = '1.0.0'
+    UsePSResourceGet     = $true
+    PSResourceGetVersion = '1.1.1'
     #UsePowerShellGetCompatibilityModule = $true
     #UsePowerShellGetCompatibilityModuleVersion = '3.0.22-beta22'
 }
-

--- a/source/Private/DSC/Assert-DscVersion.ps1
+++ b/source/Private/DSC/Assert-DscVersion.ps1
@@ -1,0 +1,40 @@
+function Assert-DscVersion
+{
+    <#
+    .SYNOPSIS
+        Assert that the required DSC version is available on GitHub
+
+    .DESCRIPTION
+        The function `Assert-DscVersion` checks if the required DSC version is available on GitHub.
+        It uses the `VersionCompleter` class to retrieve all available versions and compares them
+        against the specified required version. If the required version is not found, it throws an error.
+
+    .PARAMETER RequiredVersion
+        The version of DSC that is required. This should be a string representing the version number.
+
+    .EXAMPLE
+        This example checks if the required DSC version '1.0.0' is available:
+        ```powershell
+        Assert-DscVersion -RequiredVersion '1.0.0'
+        ```
+
+    .NOTES
+        For more details, go to module repository at: https://github.com/Gijsreyn/PSDSC.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$RequiredVersion
+    )
+
+    # Use the VersionCompleter to get all available versions
+    $completer = [VersionCompleter]::new()
+    $allVersions = $completer.CompleteArgument($null, $null, $null, $null, @{})
+
+    $versionText = $allVersions | Select-Object -ExpandProperty CompletionText
+
+    if ($versionText -notcontains $RequiredVersion)
+    {
+        throw "The required DSC version '$RequiredVersion' is not available. Available versions are: $($versionText -join ', ')"
+    }
+}

--- a/source/Private/DSC/Assert-DscVersion.ps1
+++ b/source/Private/DSC/Assert-DscVersion.ps1
@@ -9,13 +9,13 @@ function Assert-DscVersion
         It uses the `VersionCompleter` class to retrieve all available versions and compares them
         against the specified required version. If the required version is not found, it throws an error.
 
-    .PARAMETER RequiredVersion
+    .PARAMETER Version
         The version of DSC that is required. This should be a string representing the version number.
 
     .EXAMPLE
         This example checks if the required DSC version '1.0.0' is available:
         ```powershell
-        Assert-DscVersion -RequiredVersion '1.0.0'
+        Assert-DscVersion -Version '1.0.0'
         ```
 
     .NOTES
@@ -24,7 +24,7 @@ function Assert-DscVersion
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
-        [string]$RequiredVersion
+        [string]$Version
     )
 
     # Use the VersionCompleter to get all available versions
@@ -33,8 +33,8 @@ function Assert-DscVersion
 
     $versionText = $allVersions | Select-Object -ExpandProperty CompletionText
 
-    if ($versionText -notcontains $RequiredVersion)
+    if ($versionText -notcontains $Version)
     {
-        throw "The required DSC version '$RequiredVersion' is not available. Available versions are: $($versionText -join ', ')"
+        throw "The required DSC version '$Version' is not available. Available versions are: $($versionText -join ', ')"
     }
 }

--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -73,7 +73,7 @@ function Install-DscExe
 
     if ($PSBoundParameters.ContainsKey('Version'))
     {
-        Assert-DscVersion -RequiredVersion $Version
+        Assert-DscVersion -Version $Version
 
         $releaseUrl = ('{0}/tags/v{1}' -f $base, $Version)
 

--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -88,8 +88,7 @@ function Install-DscExe
                 Where-Object { -not $_.draft } |
                     Sort-Object {
                         [System.Management.Automation.SemanticVersion]::Parse(($_.tag_name -replace '^v', ''))
-                    } -Descending |
-                        Select-Object -First 1
+                    } -Descending -Top 1
 
             $prereleaseTag = $highestVersionRelease.tag_name
             $releaseUrl = ('{0}/tags/{1}' -f $base, $prereleaseTag)

--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -84,11 +84,14 @@ function Install-DscExe
         if ($IncludePrerelease.IsPresent)
         {
             $availableReleases = Invoke-RestMethod -Uri $base -Method 'Get' -Headers $headers -ErrorAction 'Stop'
-            $prereleaseTag = $availableReleases |
-                Where-Object -FilterScript { -not $_.draft -and $_.prerelease -eq $true } |
-                    Sort-Object -Property 'created_at' -Descending |
-                        Select-Object -First 1 -ExpandProperty 'tag_name'
+            $highestVersionRelease = $availableReleases |
+                Where-Object { -not $_.draft } |
+                    Sort-Object {
+                        [System.Management.Automation.SemanticVersion]::Parse(($_.tag_name -replace '^v', ''))
+                    } -Descending |
+                        Select-Object -First 1
 
+            $prereleaseTag = $highestVersionRelease.tag_name
             $releaseUrl = ('{0}/tags/{1}' -f $base, $prereleaseTag)
         }
         else

--- a/source/Public/Install-DscExe.ps1
+++ b/source/Public/Install-DscExe.ps1
@@ -73,6 +73,8 @@ function Install-DscExe
 
     if ($PSBoundParameters.ContainsKey('Version'))
     {
+        Assert-DscVersion -RequiredVersion $Version
+
         $releaseUrl = ('{0}/tags/v{1}' -f $base, $Version)
 
         $UseVersion = $true
@@ -83,7 +85,7 @@ function Install-DscExe
         {
             $availableReleases = Invoke-RestMethod -Uri $base -Method 'Get' -Headers $headers -ErrorAction 'Stop'
             $prereleaseTag = $availableReleases |
-                Where-Object -FilterScript { -not $_.draft } |
+                Where-Object -FilterScript { -not $_.draft -and $_.prerelease -eq $true } |
                     Sort-Object -Property 'created_at' -Descending |
                         Select-Object -First 1 -ExpandProperty 'tag_name'
 

--- a/tests/Unit/Private/DSC/Assert-DscVersion.tests.ps1
+++ b/tests/Unit/Private/DSC/Assert-DscVersion.tests.ps1
@@ -1,0 +1,42 @@
+BeforeAll {
+    # TODO: Find way how to install / uninstall yayaml or unload from current session
+    $script:moduleName = 'PSDSC'
+
+    # If the module is not found, run the build task 'noop'.
+    if (-not (Get-Module -Name $script:moduleName -ListAvailable))
+    {
+        # Redirect all streams to $null, except the error stream (stream 2)
+        & "$PSScriptRoot/../../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+    }
+
+    # Re-import the module using force to get any code changes between runs.
+    Import-Module -Name $script:moduleName -Force -ErrorAction 'Stop'
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:moduleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:moduleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    Remove-Module -Name $script:moduleName -Force
+}
+
+Describe 'Assert-DscVersion' -Tag Private {
+    Context 'Assert if a version of DSC is available' {
+        It 'Should asserts a correct version of DSC' {
+            InModuleScope -ScriptBlock {
+                Assert-DscVersion -Version '3.0.0'
+            }
+        }
+
+        It 'Should throw an error if the version of DSC is not available' {
+            InModuleScope -ScriptBlock {
+                { Assert-DscVersion -Version '0.0.1' } | Should -Throw
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #27 and #26. It checks if the release is actually of `PreRelease` and leverages the `[VersionCompleter]` to validate what version is passed in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to ensure the specified DSC version is available before installation.
* **Bug Fixes**
  * Improved handling of pre-release versions to ensure only genuine pre-releases are accepted.
* **Chores**
  * Updated configuration settings for dependency resolution.
  * Updated changelog with recent fixes and a new version entry.
* **Tests**
  * Introduced tests for DSC version validation functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->